### PR TITLE
[FIX] update python-dateutil library

### DIFF
--- a/python_sdk_templates/required_libraries.handlebars
+++ b/python_sdk_templates/required_libraries.handlebars
@@ -1,0 +1,16 @@
+{{#if asyncio}}
+{{#if quoted}}"{{/if}}aiohttp >= 3.0.0{{#if quoted}}",{{/if}}
+{{/if}}
+{{#if quoted}}"{{/if}}certifi >= 14.5.14{{#if quoted}}",{{/if}}
+{{#if quoted}}"{{/if}}frozendict ~= 2.3.4{{#if quoted}}",{{/if}}
+{{#if hasHttpSignatureMethods}}
+{{#if quoted}}"{{/if}}pem >= 19.3.0{{#if quoted}}",{{/if}}
+{{#if quoted}}"{{/if}}pycryptodome >= 3.9.0{{#if quoted}}",{{/if}}
+{{/if}}
+{{#if quoted}}"{{/if}}python-dateutil >= 2.7.0{{#if quoted}}",{{/if}}
+{{#if quoted}}"{{/if}}setuptools >= 21.0.0{{#if quoted}}",{{/if}}
+{{#if tornado}}
+{{#if quoted}}"{{/if}}tornado >= 4.2{{#if quoted}}",{{/if}}
+{{/if}}
+{{#if quoted}}"{{/if}}typing_extensions ~= 4.3.0{{#if quoted}}",{{/if}}
+{{#if quoted}}"{{/if}}urllib3 ~= 1.26.7{{#if quoted}}",{{/if}}


### PR DESCRIPTION
python-dateutil library ~2.7.0 is too old.